### PR TITLE
Create HIP for alternative delimiter feature

### DIFF
--- a/hips/hip-9999.md
+++ b/hips/hip-9999.md
@@ -1,0 +1,103 @@
+---
+hip: 9999
+title: "Enable use of alternative template delimiter"
+authors: [ "Neer Friedman <neerfri@gmail.com" ]
+created: "2021-11-22"
+type: "feature"
+status: "draft"
+---
+
+## Abstract
+
+Many tools use templating syntax with `{{ ... }}` delimiters, it's hard to maintain Helm charts for such tools.
+This HIP suggests to use "magic comments" in the template to control the delimiter.
+
+## Motivation
+
+Many popular kubernetes components (prometheus, argo-workflows, ...) use templating with {{...}} syntax.
+This makes it hard for helm users to template the resources for these workloads.
+The current workarounds render the templates hard to read and hard to maintain.
+
+
+## Rationale
+
+Magic comments where chosen since they allow controlling the delimiter in each template file locally, this allows
+a chart maintainer to only use the feature for templates that really need it and keep other templates "community-compatible".
+
+## Specification
+
+To change the template delimiter, a helm user would add a `# helm: delim=[,]` comment to the head of the template file:
+
+```yaml
+# helm: delim=[,]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: [[ template "chart-with-alt-delim.fullname" . ]]-alt
+data:
+  myvalue: "Hello {{world}}"
+```
+
+It's worth mentioning that the delimiter set in the `# helm: delim=[,]` is doubled in the actual template.
+This is because otherwise the comment `# helm: delim=[[,]]` would make the template engine try to execute `[[,]]` and fail.
+
+
+## Backwards compatibility
+
+The feature will have no effect on charts that do not contain the `# helm: delim=[,]` comment.
+As such it has no backwards compatibility issues.
+
+Given that the most likely reason to use the feature is the use of `{{ ... }}` in a chart template,
+templates that use the feature will error on older helm versions because the `{{ ... }}` expersion will raise an error.
+
+For example the example template in the specification above will error with:
+`Error: parse error at (chart-with-alt-delim/templates/alt-configmap.yaml:8): function "world" not defined`
+
+Chart maintainers are advised to also add a helm version requirement to their NOTES.txt template in the form of:
+
+```
+{{- $minimumHelmVersion := "3.8" }}
+{{- if semver $minimumHelmVersion | (semver .Capabilities.HelmVersion.Version).Compare | gt 0 }}
+{{- printf "Helm version must be greater than %s" $minimumHelmVersion | fail }}
+{{- end }}
+```
+
+
+## Security implications
+
+As far as the author understands this feature does not raise any additional security implications
+
+## How to teach this
+
+* Document in Helm's website
+* reference in community PRs disscussing this issue such as
+  * https://github.com/helm/helm/issues/4789
+  * https://github.com/helm/helm/issues/2931
+  * https://github.com/prometheus-community/helm-charts/issues/1505
+  * Provide a better answer here: https://stackoverflow.com/questions/64802290/how-can-i-use-argo-workflows-templates-in-helm
+
+## Reference implementation
+
+https://github.com/helm/helm/pull/10299
+
+## Rejected ideas
+
+
+## Open issues
+
+See pull request
+
+## References
+
+
+Examples of magic comments in other ecosystems:
+- [vim](https://vim.fandom.com/wiki/Modeline_magic)
+- [go-lang](https://github.com/xaionaro-go/hackery)
+- [Ruby](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/comments_rdoc.html#label-Magic+Comments)
+- [Webpack](https://webpack.js.org/api/module-methods/#magic-comments)
+
+refs #4789
+refs #2931
+https://stackoverflow.com/questions/64802290/how-can-i-use-argo-workflows-templates-in-helm
+https://stackoverflow.com/questions/56341558/how-to-escape-and-in-argo-workflow
+https://tempered.works/posts/2020-05-21-helm-argo/


### PR DESCRIPTION
Many tools use templating syntax with `{{ ... }}` delimiters, it's hard to maintain Helm charts for such tools.
This HIP suggests to use "magic comments" in the template to control the delimiter.

Signed-off-by: Neer Friedman <neerfri@gmail.com>